### PR TITLE
Time duration: support "w" for week and nicer output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ The janitor is configured via command line args, environment variables, Kubernet
 Kubernetes annotations:
 
 ``janitor/ttl``
-    Maximum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (``s``, ``m``, ``h``, ``d``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), or ``7d`` (7 days).
+    Maximum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
     Note that the actual time of deletion depends on the Janitor's clean up interval. The resource will be deleted if its age (delta between now and the resource creation time) is greater than the specified TTL.
 
 Available command line options:

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -7,10 +7,11 @@ TIME_UNIT_TO_SECONDS = {
     's': 1,
     'm': 60,
     'h': 60*60,
-    'd': 60*60*24
+    'd': 60*60*24,
+    'w': 60*60*24*7
 }
 
-TTL_PATTERN = re.compile(r'^(\d+)([smhd])$')
+TTL_PATTERN = re.compile(r'^(\d+)([smhdw])$')
 
 
 def parse_ttl(ttl: str) -> int:

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -11,6 +11,8 @@ TIME_UNIT_TO_SECONDS = {
     'w': 60*60*24*7
 }
 
+FACTOR_TO_TIME_UNIT = list(sorted([(v, k) for k, v in TIME_UNIT_TO_SECONDS.items()], reverse=True))
+
 TTL_PATTERN = re.compile(r'^(\d+)([smhdw])$')
 
 
@@ -18,7 +20,7 @@ def parse_ttl(ttl: str) -> int:
     match = TTL_PATTERN.match(ttl)
     if not match:
         raise ValueError(
-            f'TTL value "{ttl}" does not match format (e.g. 60s, 5m, 8h, 7d)')
+            f'TTL value "{ttl}" does not match format (e.g. 60s, 5m, 8h, 7d, 2w)')
 
     value = int(match.group(1))
     unit = match.group(2)
@@ -29,6 +31,27 @@ def parse_ttl(ttl: str) -> int:
         raise ValueError(f'Unknown time unit "{unit}" for TTL "{ttl}"')
 
     return value * multiplier
+
+
+def format_duration(seconds: int) -> str:
+    '''
+    Print a given duration in seconds (positive integer) as human readable duration string
+
+    >>> format_duration(3900)
+    1h5m
+    '''
+
+    parts = []
+    if seconds < 0:
+        # special handling for negative durations
+        # use positive (absolute value) with divmod, but add negative sign
+        parts.append('-')
+    remainder = abs(seconds)
+    for factor, unit in FACTOR_TO_TIME_UNIT:
+        value, remainder = divmod(remainder, factor)
+        if value > 0 or (seconds == 0 and factor == 1):
+            parts.append(f'{value}{unit}')
+    return ''.join(parts)
 
 
 def get_kube_api():

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -4,7 +4,7 @@ import pykube
 
 from collections import Counter
 
-from .helper import parse_ttl
+from .helper import parse_ttl, format_duration
 from .resources import get_namespaced_resource_types
 from pykube import Namespace
 
@@ -70,9 +70,10 @@ def handle_resource(resource, rules, dry_run: bool):
         else:
             counter[f'{resource.endpoint}-with-ttl'] = 1
             age = get_age(resource)
-            logger.debug(f'{resource.kind} {resource.name} with TTL of {ttl} is {age} old')
+            age_formatted = format_duration(int(age.total_seconds()))
+            logger.debug(f'{resource.kind} {resource.name} with TTL of {ttl} is {age_formatted} old')
             if age.total_seconds() > ttl_seconds:
-                logger.info(f'{resource.kind} {resource.name} with TTL of {ttl} is {age} old and will be deleted')
+                logger.info(f'{resource.kind} {resource.name} with TTL of {ttl} is {age_formatted} old and will be deleted')
                 delete(resource, dry_run=dry_run)
                 counter[f'{resource.endpoint}-deleted'] = 1
 

--- a/tests/test_clean_up.py
+++ b/tests/test_clean_up.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 from pykube.objects import NamespacedAPIObject
 from pykube import Namespace
-from kube_janitor.janitor import matches_resource_filter, clean_up
+from kube_janitor.janitor import matches_resource_filter, handle_resource, clean_up
 from kube_janitor.rules import Rule
 
 ALL = frozenset(['all'])
@@ -16,6 +16,25 @@ def test_matches_resource_filter():
     assert not matches_resource_filter(foo_ns, ALL, [], ALL, ['foo'])
     assert not matches_resource_filter(foo_ns, ALL, ['namespaces'], ALL, [])
     assert matches_resource_filter(foo_ns, ALL, ['deployments'], ALL, ['kube-system'])
+
+
+def test_handle_resource_no_ttl():
+    resource = Namespace(None, {'metadata': {'name': 'foo'}})
+    counter = handle_resource(resource, [], dry_run=True)
+    assert counter == {'resources-processed': 1}
+
+
+def test_handle_resource_ttl_annotation():
+    # TTL is far in the future
+    resource = Namespace(None, {'metadata': {'name': 'foo', 'annotations': {'janitor/ttl': '999w'}, 'creationTimestamp': '2019-01-17T20:59:12Z'}})
+    counter = handle_resource(resource, [], dry_run=True)
+    assert counter == {'resources-processed': 1, 'namespaces-with-ttl': 1}
+
+
+def test_handle_resource_ttl_expired():
+    resource = Namespace(None, {'metadata': {'name': 'foo', 'annotations': {'janitor/ttl': '1s'}, 'creationTimestamp': '2019-01-17T20:59:12Z'}})
+    counter = handle_resource(resource, [], dry_run=True)
+    assert counter == {'resources-processed': 1, 'namespaces-with-ttl': 1, 'namespaces-deleted': 1}
 
 
 def test_clean_up_default():

--- a/tests/test_format_duration.py
+++ b/tests/test_format_duration.py
@@ -1,0 +1,12 @@
+from kube_janitor.helper import format_duration
+
+
+def test_format_duration():
+    assert format_duration(-1) == '-1s'
+    assert format_duration(0) == '0s'
+    assert format_duration(1) == '1s'
+    assert format_duration(61) == '1m1s'
+    assert format_duration(3600) == '1h'
+    assert format_duration(3900) == '1h5m'
+    assert format_duration(3600*25) == '1d1h'
+    assert format_duration(3600*24*14) == '2w'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+import pytest
+
 import os.path
 
 from unittest.mock import MagicMock
@@ -5,10 +7,8 @@ from unittest.mock import MagicMock
 from kube_janitor.main import main
 
 
-def test_main(tmpdir, monkeypatch):
-    p = tmpdir.join("rules.yaml")
-    p.write("rules: []")
-
+@pytest.fixture
+def kubeconfig(tmpdir):
     kubeconfig = tmpdir.join('kubeconfig')
     kubeconfig.write('''
 apiVersion: v1
@@ -25,6 +25,23 @@ users:
 - name: test
   user: {token: test}
     ''')
+    return kubeconfig
+
+
+def test_main_no_rules(kubeconfig, monkeypatch):
+    monkeypatch.setattr(os.path, 'expanduser', lambda x: str(kubeconfig))
+
+    mock_clean_up = MagicMock()
+    monkeypatch.setattr('kube_janitor.main.clean_up', mock_clean_up)
+
+    main(['--dry-run', '--once'])
+
+    mock_clean_up.assert_called_once()
+
+
+def test_main_with_rules(tmpdir, kubeconfig, monkeypatch):
+    p = tmpdir.join("rules.yaml")
+    p.write("rules: []")
 
     monkeypatch.setattr(os.path, 'expanduser', lambda x: str(kubeconfig))
 

--- a/tests/test_parse_ttl.py
+++ b/tests/test_parse_ttl.py
@@ -15,3 +15,4 @@ def test_parse_ttl():
     assert parse_ttl('5m') == 300
     assert parse_ttl('2h') == 3600*2
     assert parse_ttl('7d') == 3600*24*7
+    assert parse_ttl('1w') == 3600*24*7


### PR DESCRIPTION
Fixes #7.

Also formats the resource age in a more friendly and less verbose way, e.g.:

```
INFO: Deployment nginx with TTL of 1h is 1d3h42m55s old and will be deleted
```