### PR TITLE
Emit event on resource deletion

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -9,6 +9,12 @@ metadata:
   name: kube-janitor
 rules:
 - apiGroups:
+  - v1
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
   - "*"
   resources:
   - "*"

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: kube-janitor
 rules:
 - apiGroups:
-  - v1
+  - ""
   resources:
   - events
   verbs:

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -6,7 +6,7 @@ from collections import Counter
 
 from .helper import parse_ttl, format_duration
 from .resources import get_namespaced_resource_types
-from pykube import Namespace
+from pykube import Namespace, Event
 
 logger = logging.getLogger(__name__)
 TTL_ANNOTATION = 'janitor/ttl'
@@ -39,6 +39,38 @@ def get_age(resource):
     return age
 
 
+def create_event(resource, message: str, dry_run: bool):
+    now = datetime.datetime.utcnow()
+    timestamp = now.strftime('%Y-%m-%dT%H:%M:%SZ')
+    event = Event(resource.api, {
+        'metadata': {'namespace': resource.namespace, 'generateName': 'kube-janitor-'},
+        'type': 'Normal',
+        'count': 1,
+        'firstTimestamp': timestamp,
+        'lastTimestamp': timestamp,
+        'reason': 'TimeToLiveExpired',
+        'involvedObject': {
+            'apiVersion': resource.version,
+            'name': resource.name,
+            'namespace': resource.namespace,
+            'kind': resource.kind,
+            'resourceVersion': resource.metadata.get('resourceVersion'),
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+            'uid': resource.metadata.get('uid')
+        },
+        'message': message,
+        'source': {
+            'component': 'kube-janitor'
+        }
+
+    })
+    if not dry_run:
+        try:
+            event.create()
+        except Exception as e:
+            logger.error(f'Could not create event {event.obj}: {e}')
+
+
 def delete(resource, dry_run: bool):
     if dry_run:
         logger.info(f'**DRY-RUN**: would delete {resource.kind} {resource.namespace}/{resource.name}')
@@ -54,11 +86,14 @@ def handle_resource(resource, rules, dry_run: bool):
     counter = {'resources-processed': 1}
 
     ttl = resource.annotations.get(TTL_ANNOTATION)
-    if not ttl:
+    if ttl:
+        reason = 'annotation'
+    else:
         for rule in rules:
             if rule.matches(resource):
                 logger.debug(f'Rule {rule.id} applies {rule.ttl} TTL to {resource.kind} {resource.namespace}/{resource.name}')
                 ttl = rule.ttl
+                reason = f'rule {rule.id}'
                 counter[f'rule-{rule.id}-matches'] = 1
                 # first rule which matches
                 break
@@ -71,9 +106,11 @@ def handle_resource(resource, rules, dry_run: bool):
             counter[f'{resource.endpoint}-with-ttl'] = 1
             age = get_age(resource)
             age_formatted = format_duration(int(age.total_seconds()))
-            logger.debug(f'{resource.kind} {resource.name} with TTL of {ttl} is {age_formatted} old')
+            logger.debug(f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old')
             if age.total_seconds() > ttl_seconds:
-                logger.info(f'{resource.kind} {resource.name} with TTL of {ttl} is {age_formatted} old and will be deleted')
+                message = f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old and will be deleted (reason: {reason})'
+                logger.info(message)
+                create_event(resource, message, dry_run=dry_run)
                 delete(resource, dry_run=dry_run)
                 counter[f'{resource.endpoint}-deleted'] = 1
 

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -87,13 +87,13 @@ def handle_resource(resource, rules, dry_run: bool):
 
     ttl = resource.annotations.get(TTL_ANNOTATION)
     if ttl:
-        reason = 'annotation'
+        reason = f'annotation {TTL_ANNOTATION} is set'
     else:
         for rule in rules:
             if rule.matches(resource):
                 logger.debug(f'Rule {rule.id} applies {rule.ttl} TTL to {resource.kind} {resource.namespace}/{resource.name}')
                 ttl = rule.ttl
-                reason = f'rule {rule.id}'
+                reason = f'rule {rule.id} matches'
                 counter[f'rule-{rule.id}-matches'] = 1
                 # first rule which matches
                 break
@@ -108,7 +108,7 @@ def handle_resource(resource, rules, dry_run: bool):
             age_formatted = format_duration(int(age.total_seconds()))
             logger.debug(f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old')
             if age.total_seconds() > ttl_seconds:
-                message = f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old and will be deleted (reason: {reason})'
+                message = f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old and will be deleted ({reason})'
                 logger.info(message)
                 create_event(resource, message, dry_run=dry_run)
                 delete(resource, dry_run=dry_run)

--- a/tests/test_clean_up.py
+++ b/tests/test_clean_up.py
@@ -1,3 +1,5 @@
+import json
+
 from unittest.mock import MagicMock
 
 from pykube.objects import NamespacedAPIObject
@@ -132,7 +134,7 @@ def test_clean_up_custom_resource():
 
 
 def test_clean_up_by_rule():
-    api_mock = MagicMock(spec=NamespacedAPIObject, name='APIMock')
+    api_mock = MagicMock(name='APIMock')
 
     rule = Rule.from_entry({'id': 'r1', 'resources': ['customfoos'], 'jmespath': "metadata.namespace == 'ns-1'", 'ttl': '10m'})
 
@@ -165,6 +167,14 @@ def test_clean_up_by_rule():
     assert counter['rule-r1-matches'] == 1
     assert counter['customfoos-with-ttl'] == 1
     assert counter['customfoos-deleted'] == 1
+
+    api_mock.post.assert_called_once()
+    _, kwargs = api_mock.post.call_args
+    assert kwargs['url'] == 'events'
+    data = json.loads(kwargs['data'])
+    assert data['reason'] == 'TimeToLiveExpired'
+    involvedObject = {'kind': 'CustomFoo', 'name': 'foo-1', 'namespace': 'ns-1', 'apiVersion': 'srcco.de/v1', 'resourceVersion': None, 'uid': None}
+    assert data['involvedObject'] == involvedObject
 
     # verify that the delete call happened
     api_mock.delete.assert_called_once_with(namespace='ns-1', url='customfoos/foo-1', version='srcco.de/v1')

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -66,3 +66,6 @@ def test_rule_matches():
 
     resource = StatefulSet(None, {'metadata': {'namespace': 'ns-1', 'name': 'ss-1'}})
     assert not rule.matches(resource)
+
+    resource = StatefulSet(None, {'metadata': {'namespace': 'ns-1', 'name': 'ss-1', 'labels': {'app': 'x'}}})
+    assert not rule.matches(resource)


### PR DESCRIPTION
Emit `TimeToLiveExpired` events on resource deletion.

Fixes #4.

Sample events:

```
2m          2m           1         kube-janitor-qctbm                                  Deployment                                 Normal    TimeToLiveExpired   kube-janitor            Deployment nginx3 with 1s TTL is 2m13s old and will be deleted (reason: annotation)
2m          2m           1         kube-janitor-qdt4s                                  ReplicaSet                                 Normal    TimeToLiveExpired   kube-janitor            ReplicaSet nginx3-589c484759 with 1s TTL is 2m14s old and will be deleted (reason: annotation)
```