### PR TITLE
allow "janitor/expires: YYYY-MM-DD" shortcut

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,9 @@ Kubernetes annotations:
     Maximum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
     Note that the actual time of deletion depends on the Janitor's clean up interval. The resource will be deleted if its age (delta between now and the resource creation time) is greater than the specified TTL.
 ``janitor/expires``
-    Absolute timestamp in the format ``YYYY-MM-DDTHH:MM:SSZ`` (UTC) to mark the resource for deletion after the specified date/time. Example annotation value: ``2019-02-28T20:40:00Z``.
+    Absolute timestamp in the format ``YYYY-MM-DDTHH:MM:SSZ`` or ``YYYY-MM-DD`` to mark the resource for deletion after the specified date/time.
+    The date format ``YYYY-MM-DD`` is short for ``YYYY-MM-DDT00:00:00Z``, i.e. the resource will expire at midnight UTC of the specified date.
+    Example annotation values: ``2019-02-28T20:40:00Z``, ``2019-02-28``.
 
 Available command line options:
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ TTL
 Expiry date
 -----------
 * Deploy the janitor to a test (non-prod) cluster and use namespaces with a expire date (``janitor/expires: 2020-01-17T15:14:38Z`` on the namespace object)
-* Annotate your temporary manual test nginx deployment with ``kubectl annotate deploy nginx janitor/expires=2020-01-17T15:14:38Z`` to automatically delete it by the time
+* Annotate your temporary manual test nginx deployment with ``kubectl annotate deploy nginx janitor/expires=2020-01-01`` to automatically delete it at midnight UTC of 1st of January 2020.
 
 
 Usage
@@ -72,9 +72,9 @@ Kubernetes annotations:
     Maximum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
     Note that the actual time of deletion depends on the Janitor's clean up interval. The resource will be deleted if its age (delta between now and the resource creation time) is greater than the specified TTL.
 ``janitor/expires``
-    Absolute timestamp in the format ``YYYY-MM-DDTHH:MM:SSZ`` or ``YYYY-MM-DD`` to mark the resource for deletion after the specified date/time.
+    Absolute timestamp in the format ``YYYY-MM-DDTHH:MM:SSZ``, ``YYYY-MM-DDTHH:MM`` or ``YYYY-MM-DD`` to mark the resource for deletion after the specified date/time.
     The date format ``YYYY-MM-DD`` is short for ``YYYY-MM-DDT00:00:00Z``, i.e. the resource will expire at midnight UTC of the specified date.
-    Example annotation values: ``2019-02-28T20:40:00Z``, ``2019-02-28``.
+    Example annotation values: ``2019-02-28T20:40:00Z``, ``2019-02-28T20:40``, ``2019-02-28``.
 
 Available command line options:
 

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -14,8 +14,7 @@ TIME_UNIT_TO_SECONDS = {
 
 FACTOR_TO_TIME_UNIT = list(sorted([(v, k) for k, v in TIME_UNIT_TO_SECONDS.items()], reverse=True))
 TTL_PATTERN = re.compile(r'^(\d+)([smhdw])$')
-DATETIME_PATTERN = re.compile(r'^(\d{4})-(\d{2})-(\d{2})(T)(\d{2})(:)(\d{2})(:)(\d{2})(Z)$')
-DATE_PATTERN = re.compile(r'^(\d{4})-(\d{2})-(\d{2})$')
+DATETIME_PATTERNS = ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M', '%Y-%m-%d']
 
 
 def parse_ttl(ttl: str) -> int:
@@ -36,16 +35,13 @@ def parse_ttl(ttl: str) -> int:
 
 
 def parse_expiry(expiry: str) -> datetime:
-    match = DATETIME_PATTERN.match(expiry)
-    if match:
-        return datetime.datetime.strptime(expiry, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=None)
-    else:
-        match = DATE_PATTERN.match(expiry)
-        if match:
-            return datetime.datetime.strptime(expiry, '%Y-%m-%d').replace(tzinfo=None)
-        else:
-            raise ValueError(
-                f'expiry value "{expiry}" does not match format 2019-02-25T09:26:14Z or 2019-02-25')
+    for pattern in DATETIME_PATTERNS:
+        try:
+            return datetime.datetime.strptime(expiry, pattern).replace(tzinfo=None)
+        except ValueError:
+            pass
+    raise ValueError(
+            f'expiry value "{expiry}" does not match format 2019-02-25T09:26:14Z, 2019-02-25T09:26, or 2019-02-25')
 
 
 def format_duration(seconds: int) -> str:

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -15,6 +15,7 @@ TIME_UNIT_TO_SECONDS = {
 FACTOR_TO_TIME_UNIT = list(sorted([(v, k) for k, v in TIME_UNIT_TO_SECONDS.items()], reverse=True))
 TTL_PATTERN = re.compile(r'^(\d+)([smhdw])$')
 DATETIME_PATTERN = re.compile(r'^(\d{4})-(\d{2})-(\d{2})(T)(\d{2})(:)(\d{2})(:)(\d{2})(Z)$')
+DATE_PATTERN = re.compile(r'^(\d{4})-(\d{2})-(\d{2})$')
 
 
 def parse_ttl(ttl: str) -> int:
@@ -36,10 +37,15 @@ def parse_ttl(ttl: str) -> int:
 
 def parse_expiry(expiry: str) -> datetime:
     match = DATETIME_PATTERN.match(expiry)
-    if not match:
-        raise ValueError(
-            f'expiry value "{expiry}" does not conform format 2019-02-25T09:26:14Z')
-    return datetime.datetime.strptime(expiry, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=None)
+    if match:
+        return datetime.datetime.strptime(expiry, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=None)
+    else:
+        match = DATE_PATTERN.match(expiry)
+        if match:
+            return datetime.datetime.strptime(expiry, '%Y-%m-%d').replace(tzinfo=None)
+        else:
+            raise ValueError(
+                f'expiry value "{expiry}" does not match format 2019-02-25T09:26:14Z or 2019-02-25')
 
 
 def format_duration(seconds: int) -> str:

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -120,7 +120,7 @@ def handle_resource_on_ttl(resource, rules, dry_run: bool):
 
 
 def handle_resource_on_expiry(resource, rules, dry_run: bool):
-    counter = {'resources-processed-expiry': 1}
+    counter = {}
 
     expiry = resource.annotations.get(EXPIRY_ANNOTATION)
     if expiry:
@@ -132,13 +132,13 @@ def handle_resource_on_expiry(resource, rules, dry_run: bool):
         else:
             counter[f'{resource.endpoint}-with-expiry'] = 1
             if datetime.datetime.utcnow() > expiry_timestamp:
-                message = f'{resource.kind} {resource.name} with {expiry} has expired and will be deleted ({reason})'
+                message = f'{resource.kind} {resource.name} expired on {expiry} and will be deleted ({reason})'
                 logger.info(message)
-                create_event(resource, message, "reason - current time has passes the expiry date", dry_run=dry_run)
+                create_event(resource, message, "ExpiryDateReached", dry_run=dry_run)
                 delete(resource, dry_run=dry_run)
-                counter[f'{resource.endpoint}-with-expiry-deleted'] = 1
+                counter[f'{resource.endpoint}-deleted'] = 1
             else:
-                logging.debug(f'{resource.kind} {resource.name} with {expiry} has not expired')
+                logging.debug(f'{resource.kind} {resource.name} will expire on {expiry}')
 
     return counter
 

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -134,7 +134,7 @@ def handle_resource_on_expiry(resource, rules, dry_run: bool):
             if datetime.datetime.utcnow() > expiry_timestamp:
                 message = f'{resource.kind} {resource.name} expired on {expiry} and will be deleted ({reason})'
                 logger.info(message)
-                create_event(resource, message, "ExpiryDateReached", dry_run=dry_run)
+                create_event(resource, message, "ExpiryTimeReached", dry_run=dry_run)
                 delete(resource, dry_run=dry_run)
                 counter[f'{resource.endpoint}-deleted'] = 1
             else:

--- a/tests/test_clean_up.py
+++ b/tests/test_clean_up.py
@@ -29,7 +29,7 @@ def test_handle_resource_no_ttl():
 def test_handle_resource_no_expiry():
     resource = Namespace(None, {'metadata': {'name': 'foo'}})
     counter = handle_resource_on_expiry(resource, [], dry_run=True)
-    assert counter == {'resources-processed-expiry': 1}
+    assert counter == {}
 
 
 def test_handle_resource_ttl_annotation():
@@ -45,7 +45,7 @@ def test_handle_resource_expiry_annotation():
         'name': 'foo',
         'annotations': {'janitor/expires': '2050-09-26T01:51:42Z'}}})
     counter = handle_resource_on_expiry(resource, [], dry_run=True)
-    assert counter == {'resources-processed-expiry': 1, 'namespaces-with-expiry': 1}
+    assert counter == {'namespaces-with-expiry': 1}
 
 
 def test_handle_resource_ttl_expired():
@@ -59,7 +59,7 @@ def test_handle_resource_expiry_expired():
         'name': 'foo',
         'annotations': {'janitor/expires': '2001-09-26T01:51:42Z'}}})
     counter = handle_resource_on_expiry(resource, [], dry_run=True)
-    assert counter == {'resources-processed-expiry': 1, 'namespaces-with-expiry': 1, 'namespaces-with-expiry-deleted': 1}
+    assert counter == {'namespaces-with-expiry': 1, 'namespaces-deleted': 1}
 
 
 def test_clean_up_default():
@@ -143,9 +143,9 @@ def test_ignore_invalid_expiry():
 
     api_mock.get = get
     counter = clean_up(api_mock, ALL, [], ALL, [], [], dry_run=False)
-    assert counter['resources-processed-expiry'] == 2
+    assert counter['resources-processed'] == 2
     assert counter['customfoos-with-expiry'] == 0
-    assert counter['customfoos-with-expiry-deleted'] == 0
+    assert counter['customfoos-deleted'] == 0
     assert not api_mock.delete.called
 
 
@@ -221,15 +221,15 @@ def test_clean_up_custom_resource_on_expiry():
     counter = clean_up(api_mock, ALL, [], ALL, [], [], dry_run=False)
 
     # namespace ns-1 and object foo-1
-    assert counter['resources-processed-expiry'] == 2
+    assert counter['resources-processed'] == 2
     assert counter['customfoos-with-expiry'] == 1
-    assert counter['customfoos-with-expiry-deleted'] == 1
+    assert counter['customfoos-deleted'] == 1
 
     api_mock.post.assert_called_once()
     _, kwargs = api_mock.post.call_args
     assert kwargs['url'] == 'events'
     data = json.loads(kwargs['data'])
-    assert data['reason'] == 'reason - current time has passes the expiry date'
+    assert data['reason'] == 'ExpiryDateReached'
     assert 'annotation janitor/expires is set' in data['message']
     involvedObject = {'kind': 'CustomFoo', 'name': 'foo-1', 'namespace': 'ns-1', 'apiVersion': 'srcco.de/v1', 'resourceVersion': None, 'uid': None}
     assert data['involvedObject'] == involvedObject

--- a/tests/test_clean_up.py
+++ b/tests/test_clean_up.py
@@ -229,7 +229,7 @@ def test_clean_up_custom_resource_on_expiry():
     _, kwargs = api_mock.post.call_args
     assert kwargs['url'] == 'events'
     data = json.loads(kwargs['data'])
-    assert data['reason'] == 'ExpiryDateReached'
+    assert data['reason'] == 'ExpiryTimeReached'
     assert 'annotation janitor/expires is set' in data['message']
     involvedObject = {'kind': 'CustomFoo', 'name': 'foo-1', 'namespace': 'ns-1', 'apiVersion': 'srcco.de/v1', 'resourceVersion': None, 'uid': None}
     assert data['involvedObject'] == involvedObject

--- a/tests/test_parse_expiry.py
+++ b/tests/test_parse_expiry.py
@@ -16,3 +16,4 @@ def test_parse_expiry_output_type():
 
 def test_parse_expiry_output_value_is_correct():
     assert parse_expiry('2008-09-26T01:51:42Z') == datetime.datetime(2008, 9, 26, 1, 51, 42)
+    assert parse_expiry('2008-09-26') == datetime.datetime(2008, 9, 26, 0, 0, 0)

--- a/tests/test_parse_expiry.py
+++ b/tests/test_parse_expiry.py
@@ -16,4 +16,5 @@ def test_parse_expiry_output_type():
 
 def test_parse_expiry_output_value_is_correct():
     assert parse_expiry('2008-09-26T01:51:42Z') == datetime.datetime(2008, 9, 26, 1, 51, 42)
+    assert parse_expiry('2008-09-26T01:51') == datetime.datetime(2008, 9, 26, 1, 51, 0)
     assert parse_expiry('2008-09-26') == datetime.datetime(2008, 9, 26, 0, 0, 0)


### PR DESCRIPTION
Follow up to #6: allow shorthand format with date only (assumes 00:00 UTC).