### PR TITLE
[W.I.P] Add hacky support for deleting a helm release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.7-alpine3.9
 MAINTAINER Henning Jacobs <henning@jacobs1.de>
 
+RUN apk --no-cache add git gcc musl-dev g++
+
 WORKDIR /
 
 COPY Pipfile.lock /
@@ -11,6 +13,8 @@ RUN /pipenv-install.py && \
     rm -fr /usr/local/lib/python3.7/site-packages/setuptools
 
 FROM python:3.7-alpine3.9
+
+RUN apk --no-cache add libstdc++
 
 WORKDIR /
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,8 @@ name = "pypi"
 
 [packages]
 jmespath = "*"
-pykube-ng = "*"
+pykube-ng = {extras = ["gcp"],version = "*"}
+pyhelm = {git = "https://github.com/imduffy15/pyhelm",ref = "master"}
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f39a7e75c780774e2cf9885b076c01728e1cfda89def3d64989bbf7efc83fa36"
+            "sha256": "8ce36237eedfb792c89c47ab60de512ac4af6951cd5a7cea8cd79384bb402512"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "cachetools": {
+            "hashes": [
+                "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae",
+                "sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a"
+            ],
+            "version": "==3.1.1"
+        },
         "certifi": {
             "hashes": [
                 "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
@@ -29,6 +36,20 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4",
+                "sha256:20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed"
+            ],
+            "version": "==1.6.3"
         },
         "idna": {
             "hashes": [
@@ -45,7 +66,42 @@
             "index": "pypi",
             "version": "==0.9.4"
         },
+        "jsonpath-ng": {
+            "hashes": [
+                "sha256:0aeb1e9f5232bb9e1b34f02b90ac51a80100b66ffc742e0b11df93ccbde82765",
+                "sha256:b1fc75b877e9b2f46845a455fbdcfb0f0d9c727c45c19a745d02db620a9ef0be"
+            ],
+            "version": "==1.4.3"
+        },
+        "ply": {
+            "hashes": [
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+            ],
+            "version": "==3.11"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
+                "sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e"
+            ],
+            "version": "==0.4.5"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:ef721f68f7951fab9b0404d42590f479e30d9005daccb1699b0a51bb4177db96",
+                "sha256:f309b6c94724aeaf7ca583feb1cc70430e10d7551de5e36edfc1ae6909bcfb3c"
+            ],
+            "version": "==0.2.5"
+        },
+        "pyhelm": {
+            "git": "https://github.com/imduffy15/pyhelm",
+            "ref": "6acf3214e6a23bbbefd0d3609bf90106860090a3"
+        },
         "pykube-ng": {
+            "extras": [
+                "gcp"
+            ],
             "hashes": [
                 "sha256:d8f13e1638b48131781d52068e32c9664fba65cff02cd013ff43bd1a7de59a7d",
                 "sha256:e8d7413a9f7a2776be6a3a3fab58790cfe2fd9fde20704cdb4e77f5f21ae789a"
@@ -71,17 +127,31 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.1"
+            "version": "==1.25.3"
         }
     },
     "develop": {
@@ -115,42 +185,32 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:0c5fe441b9cfdab64719f24e9684502a59432df7570521563d7b1aff27ac755f",
-                "sha256:2b412abc4c7d6e019ce7c27cbc229783035eef6d5401695dccba80f481be4eb3",
                 "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
                 "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
                 "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
-                "sha256:42692db854d13c6c5e9541b6ffe0fe921fe16c9c446358d642ccae1462582d3b",
                 "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
                 "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
-                "sha256:4ec30ade438d1711562f3786bea33a9da6107414aed60a5daa974d50a8c2c351",
                 "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
                 "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
-                "sha256:6899797ac384b239ce1926f3cb86ffc19996f6fa3a1efbb23cb49e0c12d8c18c",
                 "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
                 "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
                 "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
                 "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
                 "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
-                "sha256:8e679d1bde5e2de4a909efb071f14b472a678b788904440779d2c449c0355b27",
                 "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
                 "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
-                "sha256:93f965415cc51604f571e491f280cff0f5be35895b4eb5e55b47ae90c02a497b",
                 "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
                 "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
                 "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
                 "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
                 "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
                 "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
-                "sha256:a9abc8c480e103dc05d9b332c6cc9fb1586330356fc14f1aa9c0ca5745097d19",
                 "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
                 "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
                 "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
-                "sha256:c22ab9f96cbaff05c6a84e20ec856383d27eae09e511d3e6ac4479489195861d",
                 "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
                 "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
                 "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
-                "sha256:ca58eba39c68010d7e87a823f22a081b5290e3e3c64714aac3c91481d8b34d22",
                 "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
                 "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
                 "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
@@ -162,11 +222,11 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:baa26648430d5c2225ab12d7e2067f75597a4b967034bba7e3d5ab7501d207a1",
-                "sha256:ff9b7823b15070f26f654837bb02a201d006baaf2083e0514ffd3b34a3ffed81"
+                "sha256:a8de28a5f04e418c7142b8ce6588c3a64245b433c458a5871cb043383667e4f2",
+                "sha256:c5e50b73b980d89308816b597e3e7bdeb0adedf831585d5c4ac967d576f8925d"
             ],
             "index": "pypi",
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "docopt": {
             "hashes": [
@@ -196,6 +256,13 @@
             ],
             "version": "==2.8"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:a9f185022cfa69e9ca5f7eabfd5a58b689894cb78a11e3c8c89398a8ccbb8e7f",
+                "sha256:df1403cd3aebeb2b1dcd3515ca062eecb5bd3ea7611f18cba81130c68707e879"
+            ],
+            "version": "==0.17"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
@@ -211,12 +278,19 @@
             "markers": "python_version > '2.7'",
             "version": "==7.0.0"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -239,28 +313,35 @@
             ],
             "version": "==2.1.1"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
+        },
         "pytest": {
             "hashes": [
-                "sha256:13c5e9fb5ec5179995e9357111ab089af350d788cbc944c628f3cde72285809b",
-                "sha256:f21d2f1fb8200830dcbb5d8ec466a9c9120e20d8b53c7585d180125cce1d297a"
+                "sha256:6032845e68a17a96e8da3088037f899b56357769a724122056265ca2ea1890ee",
+                "sha256:bea27a646a3d74cbbcf8d3d4a06b2dfc336baf3dc2cc85cf70ad0157e73e8322"
             ],
             "index": "pypi",
-            "version": "==4.4.0"
+            "version": "==4.6.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
-                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
+                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
+                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
             ],
             "index": "pypi",
-            "version": "==2.6.1"
+            "version": "==2.7.1"
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "six": {
             "hashes": [
@@ -271,10 +352,24 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.1"
+            "version": "==1.25.3"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     }
 }

--- a/kube_janitor/cmd.py
+++ b/kube_janitor/cmd.py
@@ -1,6 +1,5 @@
-import os
-
 import argparse
+import os
 
 DEFAULT_EXCLUDE_RESOURCES = 'events,controllerrevisions'
 DEFAULT_EXCLUDE_NAMESPACES = 'kube-system'
@@ -24,4 +23,6 @@ def get_parser():
                         default=os.getenv('EXCLUDE_NAMESPACES', DEFAULT_EXCLUDE_NAMESPACES))
     parser.add_argument('--rules-file', help='Load TTL rules from given file path',
                         default=os.getenv('RULES_FILE'))
+    parser.add_argument('--tiller-host', help='Tiller host', default=os.getenv('TILLER_HOST'))
+    parser.add_argument('--tiller-port', help='Tiller port', default=os.getenv('TILLER_PORT'))
     return parser

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -1,9 +1,8 @@
-import os
-
 import datetime
-import pykube
+import os
 import re
 
+import pykube
 
 TIME_UNIT_TO_SECONDS = {
     's': 1,
@@ -42,7 +41,7 @@ def parse_expiry(expiry: str) -> datetime:
         except ValueError:
             pass
     raise ValueError(
-            f'expiry value "{expiry}" does not match format 2019-02-25T09:26:14Z, 2019-02-25T09:26, or 2019-02-25')
+        f'expiry value "{expiry}" does not match format 2019-02-25T09:26:14Z, 2019-02-25T09:26, or 2019-02-25')
 
 
 def format_duration(seconds: int) -> str:

--- a/kube_janitor/main.py
+++ b/kube_janitor/main.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
-import time
 import logging
+import time
+
+from pyhelm.tiller import Tiller
 
 from kube_janitor import __version__, cmd, shutdown
 from kube_janitor.helper import get_kube_api
@@ -30,25 +32,32 @@ def main(args=None):
     else:
         rules = []
 
+    if args.tiller_host and args.tiller_port:
+        tiller = Tiller(args.tiller_host, args.tiller_port)
+    else:
+        tiller = None
+
     return run_loop(args.once, args.include_resources, args.exclude_resources, args.include_namespaces,
-                    args.exclude_namespaces, rules, args.interval, args.delete_notification, args.dry_run)
+                    args.exclude_namespaces, rules, args.interval, args.delete_notification, args.dry_run, tiller)
 
 
 def run_loop(run_once, include_resources, exclude_resources, include_namespaces, exclude_namespaces,
-             rules, interval, delete_notification, dry_run):
+             rules, interval, delete_notification, dry_run, tiller):
     handler = shutdown.GracefulShutdown()
     while True:
         try:
             api = get_kube_api()
             clean_up(
-                  api,
-                  include_resources=frozenset(include_resources.split(',')),
-                  exclude_resources=frozenset(exclude_resources.split(',')),
-                  include_namespaces=frozenset(include_namespaces.split(',')),
-                  exclude_namespaces=frozenset(exclude_namespaces.split(',')),
-                  rules=rules,
-                  delete_notification=delete_notification,
-                  dry_run=dry_run)
+                api,
+                include_resources=frozenset(include_resources.split(',')),
+                exclude_resources=frozenset(exclude_resources.split(',')),
+                include_namespaces=frozenset(include_namespaces.split(',')),
+                exclude_namespaces=frozenset(exclude_namespaces.split(',')),
+                rules=rules,
+                delete_notification=delete_notification,
+                dry_run=dry_run,
+                tiller=tiller
+            )
         except Exception as e:
             logger.exception('Failed to clean up: %s', e)
         if run_once or handler.shutdown_now:

--- a/pipenv-install.py
+++ b/pipenv-install.py
@@ -10,6 +10,11 @@ with open("Pipfile.lock") as fd:
 
 packages = []
 for k, v in data["default"].items():
-    packages.append(k + v["version"])
+    if 'version' in v:
+        packages.append(k + v["version"])
+    elif 'git' in v:
+        packages.append(f"git+{v['git']}.git@{v['ref']}")
+    else:
+        raise Exception(f"Could not find a valid version for {k}")
 
 subprocess.run(["pip3", "install"] + packages, check=True)

--- a/tests/test_delete_notification.py
+++ b/tests/test_delete_notification.py
@@ -1,12 +1,13 @@
 import datetime
 import unittest
 
+from pykube import Namespace
+from pykube.utils import obj_merge
+
 from kube_janitor.janitor import (add_notification_flag,
                                   get_delete_notification_time, get_ttl_expiry_time,
                                   handle_resource_on_expiry,
                                   handle_resource_on_ttl, was_notified)
-from pykube import Namespace
-from pykube.utils import obj_merge
 
 
 class MockedNamespace(Namespace):
@@ -54,7 +55,7 @@ class TestDeleteNotification(unittest.TestCase):
         # Notification is 3 minutes: 180s. Has to notify after: 2019-03-11T11:12:00Z
         resource = Namespace(None, {'metadata': {'name': 'foo', 'annotations': {'janitor/ttl': '10m'}, 'creationTimestamp': '2019-03-11T11:05:00Z'}})
         delete_notification = 180
-        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True)
+        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True, tiller=None)
         mocked_add_notification_flag.assert_not_called()
 
     @unittest.mock.patch('kube_janitor.janitor.utcnow', return_value=datetime.datetime.strptime('2019-03-11T11:13:09Z', '%Y-%m-%dT%H:%M:%SZ'))
@@ -66,7 +67,7 @@ class TestDeleteNotification(unittest.TestCase):
         # Notification is 3 minutes: 180s. Has to notify after: 2019-03-11T11:12:00Z
         resource = Namespace(None, {'metadata': {'name': 'foo', 'annotations': {'janitor/ttl': '10m'}, 'creationTimestamp': '2019-03-11T11:05:00Z'}})
         delete_notification = 180
-        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True)
+        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True, tiller=None)
         mocked_add_notification_flag.assert_called()
 
     @unittest.mock.patch('kube_janitor.janitor.utcnow', return_value=datetime.datetime.strptime('2019-03-11T11:13:09Z', '%Y-%m-%dT%H:%M:%SZ'))
@@ -78,7 +79,7 @@ class TestDeleteNotification(unittest.TestCase):
         # Notification is 3 minutes: 180s. Has to notify after: 2019-03-11T11:12:00Z
         resource = MockedNamespace(None, {'metadata': {'name': 'foo', 'annotations': {'janitor/ttl': '10m'}, 'creationTimestamp': '2019-03-11T11:05:00Z'}})
         delete_notification = 180
-        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True)
+        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True, tiller=None)
         expire = datetime.datetime.strptime('2019-03-11T11:15:00Z', '%Y-%m-%dT%H:%M:%SZ')
         formatted_expire_datetime = expire.strftime('%Y-%m-%dT%H:%M:%SZ')
         reason = 'annotation janitor/ttl is set'


### PR DESCRIPTION
If `tiller-host` and `tiller-port` arguments are passed and the resource
has a `release` label rather than executing a delete on the kubernetes
resource this will execute a `helm delete --purge {release}` and delete
the whole helm release.

Open to ideas on how to better handle this or if it is something of
interest to the project.