### PR TITLE
Allow to use `forever` as ttl for a resource.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,8 @@ The janitor is configured via command line args, environment variables, Kubernet
 Supported Kubernetes annotations:
 
 ``janitor/ttl``
-    Maximum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
+    Minimum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
+    In case if resource should not be deleted by janitor - it is allowed to specify `forever`.
     Note that the actual time of deletion depends on the Janitor's clean up interval. The resource will be deleted if its age (delta between now and the resource creation time) is greater than the specified TTL.
 ``janitor/expires``
     Absolute timestamp in the format ``YYYY-MM-DDTHH:MM:SSZ``, ``YYYY-MM-DDTHH:MM`` or ``YYYY-MM-DD`` to mark the resource for deletion after the specified date/time.

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ The janitor is configured via command line args, environment variables, Kubernet
 Supported Kubernetes annotations:
 
 ``janitor/ttl``
-    Minimum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
+    Maximum time to live (TTL) for the annotated resource. Annotation value must be a string composed of a integer value and a unit suffix (one of ``s``, ``m``, ``h``, ``d``, or ``w``), e.g. ``120s`` (120 seconds), ``5m`` (5 minutes), ``8h`` (8 hours), ``7d`` (7 days), or ``2w`` (2 weeks).
     In case if resource should not be deleted by janitor - it is allowed to specify `forever`.
     Note that the actual time of deletion depends on the Janitor's clean up interval. The resource will be deleted if its age (delta between now and the resource creation time) is greater than the specified TTL.
 ``janitor/expires``

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -17,8 +17,12 @@ FACTOR_TO_TIME_UNIT = list(sorted([(v, k) for k, v in TIME_UNIT_TO_SECONDS.items
 TTL_PATTERN = re.compile(r'^(\d+)([smhdw])$')
 DATETIME_PATTERNS = ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M', '%Y-%m-%d']
 
+TTL_UNLIMITED = 'forever'
+
 
 def parse_ttl(ttl: str) -> int:
+    if lower(ttl) == TTL_UNLIMITED:
+        return -1
     match = TTL_PATTERN.match(ttl)
     if not match:
         raise ValueError(

--- a/kube_janitor/helper.py
+++ b/kube_janitor/helper.py
@@ -21,7 +21,7 @@ TTL_UNLIMITED = 'forever'
 
 
 def parse_ttl(ttl: str) -> int:
-    if lower(ttl) == TTL_UNLIMITED:
+    if ttl.lower() == TTL_UNLIMITED:
         return -1
     match = TTL_PATTERN.match(ttl)
     if not match:

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -141,21 +141,23 @@ def handle_resource_on_ttl(resource, rules, delete_notification: int, dry_run: b
         except ValueError as e:
             logger.info(f'Ignoring invalid TTL on {resource.kind} {resource.name}: {e}')
         else:
-            counter[f'{resource.endpoint}-with-ttl'] = 1
-            age = get_age(resource)
-            age_formatted = format_duration(int(age.total_seconds()))
-            logger.debug(f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old')
-            if age.total_seconds() > ttl_seconds:
-                message = f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old and will be deleted ({reason})'
-                logger.info(message)
-                create_event(resource, message, "TimeToLiveExpired", dry_run=dry_run)
-                delete(resource, dry_run=dry_run)
-                counter[f'{resource.endpoint}-deleted'] = 1
-            elif delete_notification:
-                expiry_time = get_ttl_expiry_time(resource, ttl_seconds)
-                notification_time = get_delete_notification_time(expiry_time, delete_notification)
-                if utcnow() > notification_time and not was_notified(resource):
-                    send_delete_notification(resource, reason, expiry_time, dry_run=dry_run)
+            if ttl_seconds > 0:
+                counter[f'{resource.endpoint}-with-ttl'] = 1
+                age = get_age(resource)
+                age_formatted = format_duration(int(age.total_seconds()))
+                logger.debug(f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old')
+                if age.total_seconds() > ttl_seconds:
+                    message = f'{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old and will be deleted ({reason})'
+                    logger.info(message)
+                    create_event(resource, message, "TimeToLiveExpired", dry_run=dry_run)
+                    delete(resource, dry_run=dry_run)
+                    counter[f'{resource.endpoint}-deleted'] = 1
+                elif delete_notification:
+                    expiry_time = get_ttl_expiry_time(resource, ttl_seconds)
+                    notification_time = get_delete_notification_time(expiry_time, delete_notification)
+                    if utcnow() > notification_time and not was_notified(resource):
+                        send_delete_notification(resource, reason, expiry_time, dry_run=dry_run)
+
 
     return counter
 

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -158,7 +158,6 @@ def handle_resource_on_ttl(resource, rules, delete_notification: int, dry_run: b
                     if utcnow() > notification_time and not was_notified(resource):
                         send_delete_notification(resource, reason, expiry_time, dry_run=dry_run)
 
-
     return counter
 
 

--- a/tests/test_parse_ttl.py
+++ b/tests/test_parse_ttl.py
@@ -16,3 +16,5 @@ def test_parse_ttl():
     assert parse_ttl('2h') == 3600*2
     assert parse_ttl('7d') == 3600*24*7
     assert parse_ttl('1w') == 3600*24*7
+
+    assert parse_ttl('forever') < 0


### PR DESCRIPTION
Closes #38