### PR TITLE
Add support for --deployment-time-annotation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,8 @@ Available command line options:
     This option takes precedence over ``--include-namespaces``, i.e. ``--exclude-namespaces=ns1`` in combination with ``--include-namespaces=ns1,ns2`` would only process resources in the ``ns2`` namespace.
 ``--rules-file``
     Optional: filename pointing to a YAML file with a list of rules to apply TTL values to arbitrary Kubernetes objects, e.g. to delete all deployments without a certain label automatically after N days. See Rules File configuration section below.
+``--deployment-time-annotation``
+    Optional: name of the annotation that would be used instead of the creation timestamp of the resource. This option should be used if you want the resources to not be cleaned up if they've been recently redeployed, and your deployment tooling can set this annotation.
 
 Example flags:
 

--- a/kube_janitor/cmd.py
+++ b/kube_janitor/cmd.py
@@ -52,4 +52,9 @@ def get_parser():
         help="Load TTL rules from given file path",
         default=os.getenv("RULES_FILE"),
     )
+    parser.add_argument(
+        "--deployment-time-annotation",
+        help="Annotation that contains a resource's last deployment time, overrides creationTime",
+        required=False,
+    )
     return parser

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from collections import Counter
+from typing import Optional
 
 import pykube
 from pykube import Event
@@ -50,11 +51,20 @@ def matches_resource_filter(
     )
 
 
-def get_ttl_expiry_time(resource, ttl_seconds: int) -> datetime.datetime:
-    creation_time = datetime.datetime.strptime(
-        resource.metadata["creationTimestamp"], "%Y-%m-%dT%H:%M:%SZ"
+def get_deployment_time(
+    resource, deployment_time_annotation: Optional[str]
+) -> datetime.datetime:
+    metadata = resource.metadata
+    creation_time = metadata["creationTimestamp"]
+    deployment_time = (
+        metadata.get("annotations", {}).get(deployment_time_annotation)
+        if deployment_time_annotation
+        else None
     )
-    return creation_time + datetime.timedelta(seconds=ttl_seconds)
+
+    return datetime.datetime.strptime(
+        deployment_time or creation_time, "%Y-%m-%dT%H:%M:%SZ"
+    )
 
 
 def get_delete_notification_time(
@@ -75,15 +85,6 @@ def add_notification_flag(resource, dry_run: bool):
 
 def was_notified(resource):
     return NOTIFIED_ANNOTATION in resource.annotations.keys()
-
-
-def get_age(resource):
-    creation_time = datetime.datetime.strptime(
-        resource.metadata["creationTimestamp"], "%Y-%m-%dT%H:%M:%SZ"
-    )
-    now = utcnow()
-    age = now - creation_time
-    return age
 
 
 def utcnow():
@@ -155,7 +156,13 @@ def delete(resource, dry_run: bool):
             )
 
 
-def handle_resource_on_ttl(resource, rules, delete_notification: int, dry_run: bool):
+def handle_resource_on_ttl(
+    resource,
+    rules,
+    delete_notification: int,
+    deployment_time_annotation: Optional[str],
+    dry_run: bool,
+):
     counter = {"resources-processed": 1}
 
     ttl = resource.annotations.get(TTL_ANNOTATION)
@@ -180,7 +187,10 @@ def handle_resource_on_ttl(resource, rules, delete_notification: int, dry_run: b
         else:
             if ttl_seconds > 0:
                 counter[f"{resource.endpoint}-with-ttl"] = 1
-                age = get_age(resource)
+                deployment_time = get_deployment_time(
+                    resource, deployment_time_annotation
+                )
+                age = utcnow() - deployment_time
                 age_formatted = format_duration(int(age.total_seconds()))
                 logger.debug(
                     f"{resource.kind} {resource.name} with {ttl} TTL is {age_formatted} old"
@@ -194,7 +204,9 @@ def handle_resource_on_ttl(resource, rules, delete_notification: int, dry_run: b
                     delete(resource, dry_run=dry_run)
                     counter[f"{resource.endpoint}-deleted"] = 1
                 elif delete_notification:
-                    expiry_time = get_ttl_expiry_time(resource, ttl_seconds)
+                    expiry_time = deployment_time + datetime.timedelta(
+                        seconds=ttl_seconds
+                    )
                     notification_time = get_delete_notification_time(
                         expiry_time, delete_notification
                     )
@@ -251,6 +263,7 @@ def clean_up(
     exclude_namespaces: frozenset,
     rules: list,
     delete_notification: int,
+    deployment_time_annotation: Optional[str],
     dry_run: bool,
 ):
 
@@ -265,7 +278,13 @@ def clean_up(
             exclude_namespaces,
         ):
             counter.update(
-                handle_resource_on_ttl(namespace, rules, delete_notification, dry_run)
+                handle_resource_on_ttl(
+                    namespace,
+                    rules,
+                    delete_notification,
+                    deployment_time_annotation,
+                    dry_run,
+                )
             )
             counter.update(
                 handle_resource_on_expiry(
@@ -307,7 +326,13 @@ def clean_up(
 
     for resource in filtered_resources:
         counter.update(
-            handle_resource_on_ttl(resource, rules, delete_notification, dry_run)
+            handle_resource_on_ttl(
+                resource,
+                rules,
+                delete_notification,
+                deployment_time_annotation,
+                dry_run,
+            )
         )
         counter.update(
             handle_resource_on_expiry(resource, rules, delete_notification, dry_run)

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -55,15 +55,19 @@ def get_deployment_time(
     resource, deployment_time_annotation: Optional[str]
 ) -> datetime.datetime:
     metadata = resource.metadata
-    creation_time = metadata["creationTimestamp"]
-    deployment_time = (
-        metadata.get("annotations", {}).get(deployment_time_annotation)
+    annotations = metadata.get("annotations", {})
+
+    creation_timestamp = metadata["creationTimestamp"]
+    deployment_timestamp = (
+        annotations.get(deployment_time_annotation)
         if deployment_time_annotation
         else None
     )
 
-    return datetime.datetime.strptime(
-        deployment_time or creation_time, "%Y-%m-%dT%H:%M:%SZ"
+    return max(
+        datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+        for timestamp in (creation_timestamp, deployment_timestamp)
+        if timestamp is not None
     )
 
 

--- a/kube_janitor/main.py
+++ b/kube_janitor/main.py
@@ -42,6 +42,7 @@ def main(args=None):
         rules,
         args.interval,
         args.delete_notification,
+        args.deployment_time_annotation,
         args.dry_run,
     )
 
@@ -55,6 +56,7 @@ def run_loop(
     rules,
     interval,
     delete_notification,
+    deployment_time_annotation,
     dry_run,
 ):
     handler = shutdown.GracefulShutdown()
@@ -69,6 +71,7 @@ def run_loop(
                 exclude_namespaces=frozenset(exclude_namespaces.split(",")),
                 rules=rules,
                 delete_notification=delete_notification,
+                deployment_time_annotation=deployment_time_annotation,
                 dry_run=dry_run,
             )
         except Exception as e:

--- a/tests/test_clean_up.py
+++ b/tests/test_clean_up.py
@@ -124,6 +124,32 @@ def test_handle_resource_deployment_time_no_expiry():
 
 
 @mock_now
+def test_handle_resource_deployment_time_creation_time_later():
+    # deployment time + TTL is in the past, but creation time + TTL is in the future
+    resource = Namespace(
+        None,
+        {
+            "metadata": {
+                "name": "foo",
+                "annotations": {
+                    "janitor/ttl": "1w",
+                    "deploymentTimestamp": "2019-03-01T11:13:09Z",
+                },
+                "creationTimestamp": "2019-03-02T11:13:09Z",
+            }
+        },
+    )
+    counter = handle_resource_on_ttl(
+        resource, [], 0, deployment_time_annotation="deploymentTimestamp", dry_run=True
+    )
+    assert counter == {
+        "resources-processed": 1,
+        "namespaces-with-ttl": 1,
+        "namespaces-deleted": 1,
+    }
+
+
+@mock_now
 def test_handle_resource_deployment_time_both_expired():
     # both creation time + TTL and deployment time + TTL are in the past
     resource = Namespace(

--- a/tests/test_clean_up.py
+++ b/tests/test_clean_up.py
@@ -124,6 +124,32 @@ def test_handle_resource_deployment_time_no_expiry():
 
 
 @mock_now
+def test_handle_resource_deployment_time_invalid():
+    # creation time + TTL is in the past, and deployment time is invalid
+    resource = Namespace(
+        None,
+        {
+            "metadata": {
+                "name": "foo",
+                "annotations": {
+                    "janitor/ttl": "1w",
+                    "deploymentTimestamp": "2019-03-ABCD",
+                },
+                "creationTimestamp": "2019-03-01T11:13:09Z",
+            }
+        },
+    )
+    counter = handle_resource_on_ttl(
+        resource, [], 0, deployment_time_annotation="deploymentTimestamp", dry_run=True
+    )
+    assert counter == {
+        "resources-processed": 1,
+        "namespaces-with-ttl": 1,
+        "namespaces-deleted": 1,
+    }
+
+
+@mock_now
 def test_handle_resource_deployment_time_creation_time_later():
     # deployment time + TTL is in the past, but creation time + TTL is in the future
     resource = Namespace(

--- a/tests/test_delete_notification.py
+++ b/tests/test_delete_notification.py
@@ -6,7 +6,6 @@ from pykube.utils import obj_merge
 
 from kube_janitor.janitor import add_notification_flag
 from kube_janitor.janitor import get_delete_notification_time
-from kube_janitor.janitor import get_ttl_expiry_time
 from kube_janitor.janitor import handle_resource_on_expiry
 from kube_janitor.janitor import handle_resource_on_ttl
 from kube_janitor.janitor import was_notified
@@ -30,14 +29,6 @@ class TestDeleteNotification(unittest.TestCase):
                 }
             },
         )
-
-    def test_get_ttl_expiry_time(self):
-        ttl_seconds = 300  # 5 minutes
-        expected_expire = datetime.datetime.strptime(
-            "2019-03-11T11:15:09Z", "%Y-%m-%dT%H:%M:%SZ"
-        )
-        expire = get_ttl_expiry_time(self.mocked_resource, ttl_seconds)
-        self.assertEqual(expire, expected_expire)
 
     def test_add_notification_flag(self):
         add_notification_flag(self.mocked_resource, dry_run=False)
@@ -98,7 +89,13 @@ class TestDeleteNotification(unittest.TestCase):
             },
         )
         delete_notification = 180
-        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True)
+        handle_resource_on_ttl(
+            resource,
+            [],
+            delete_notification,
+            deployment_time_annotation=None,
+            dry_run=True,
+        )
         mocked_add_notification_flag.assert_not_called()
 
     @unittest.mock.patch(
@@ -126,7 +123,13 @@ class TestDeleteNotification(unittest.TestCase):
             },
         )
         delete_notification = 180
-        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True)
+        handle_resource_on_ttl(
+            resource,
+            [],
+            delete_notification,
+            deployment_time_annotation=None,
+            dry_run=True,
+        )
         mocked_add_notification_flag.assert_called()
 
     @unittest.mock.patch(
@@ -155,7 +158,11 @@ class TestDeleteNotification(unittest.TestCase):
         )
         delete_notification = 180
         counter = handle_resource_on_ttl(
-            resource, [], delete_notification, dry_run=True
+            resource,
+            [],
+            delete_notification,
+            deployment_time_annotation=None,
+            dry_run=True,
         )
         self.assertEqual(1, counter["resources-processed"])
         self.assertEqual(1, len(counter))
@@ -186,7 +193,58 @@ class TestDeleteNotification(unittest.TestCase):
             },
         )
         delete_notification = 180
-        handle_resource_on_ttl(resource, [], delete_notification, dry_run=True)
+        handle_resource_on_ttl(
+            resource,
+            [],
+            delete_notification,
+            deployment_time_annotation=None,
+            dry_run=True,
+        )
+        expire = datetime.datetime.strptime(
+            "2019-03-11T11:15:00Z", "%Y-%m-%dT%H:%M:%SZ"
+        )
+        formatted_expire_datetime = expire.strftime("%Y-%m-%dT%H:%M:%SZ")
+        reason = "annotation janitor/ttl is set"
+        message = f"{resource.kind} {resource.name} will be deleted at {formatted_expire_datetime} ({reason})"
+        mocked_create_event.assert_called_with(
+            resource, message, "DeleteNotification", dry_run=True
+        )
+
+    @unittest.mock.patch(
+        "kube_janitor.janitor.utcnow",
+        return_value=datetime.datetime.strptime(
+            "2019-03-11T11:13:09Z", "%Y-%m-%dT%H:%M:%SZ"
+        ),
+    )
+    @unittest.mock.patch("kube_janitor.janitor.create_event")
+    def test_handle_resource_ttl_annotation_notification_deployment_time_event(
+        self, mocked_create_event, mocked_utcnow
+    ):
+        # Resource was created at 2019-03-01T00:00:00Z and redeployed at 2019-03-11T11:05:00Z
+        # ttl is 10 minutes, so it will expire: 2019-03-11T11:15:00Z
+        # Current datetime is: 2019-03-11T11:13:09Z
+        # Notification is 3 minutes: 180s. Has to notify after: 2019-03-11T11:12:00Z
+        resource = MockedNamespace(
+            None,
+            {
+                "metadata": {
+                    "name": "foo",
+                    "annotations": {
+                        "janitor/ttl": "10m",
+                        "deploymentTime": "2019-03-11T11:05:00Z",
+                    },
+                    "creationTimestamp": "2019-03-01T00:00:00Z",
+                }
+            },
+        )
+        delete_notification = 180
+        handle_resource_on_ttl(
+            resource,
+            [],
+            delete_notification,
+            deployment_time_annotation="deploymentTime",
+            dry_run=True,
+        )
         expire = datetime.datetime.strptime(
             "2019-03-11T11:15:00Z", "%Y-%m-%dT%H:%M:%SZ"
         )


### PR DESCRIPTION
Adds an optional `--deployment-time` annotation that overrides of `creationTimestamp` if present on a resource.