### PR TITLE
Add namespace warnings to README and rbac.yaml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,8 @@ Usage
 
 Deploy the janitor into your cluster via (also works with Minikube_):
 
+    Warning: if you want to deploy janitor to namespace other than ``default``, you need to edit ``/deploy/common/rbac.yaml`` first.
+
 .. code-block:: bash
 
     $ kubectl apply -f deploy/common/

--- a/deploy/common/rbac.yaml
+++ b/deploy/common/rbac.yaml
@@ -35,4 +35,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-janitor
+  # change the namespace name below if you want to deploy to a different namespace
   namespace: default


### PR DESCRIPTION
# what

Add namespace warnings to`README.rst` and `deploy/common/rbac.yaml`

# why

- The current deployment manifests assume that kube-janitor is deployed to the `default` Kubernetes namespace. If kube-janitor is deployed to a different namespace, this can lead to problems described in #35, at least on GKE.
- The author solicited this PR [over here](https://github.com/hjacobs/kube-janitor/issues/35#issuecomment-559446225)

# notes

- This is a documentation/comment only PR. It contains no code or configuration changes.