### PR TITLE
Remove unmounted/unused PVCs

### DIFF
--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -10,6 +10,7 @@ from pykube import Namespace
 from .helper import format_duration
 from .helper import parse_expiry
 from .helper import parse_ttl
+from .resource_context import get_resource_context
 from .resources import get_namespaced_resource_types
 
 logger = logging.getLogger(__name__)
@@ -176,8 +177,9 @@ def handle_resource_on_ttl(
     if ttl:
         reason = f"annotation {TTL_ANNOTATION} is set"
     else:
+        context = get_resource_context(resource)
         for rule in rules:
-            if rule.matches(resource):
+            if rule.matches(resource, context):
                 logger.debug(
                     f"Rule {rule.id} applies {rule.ttl} TTL to {resource.kind} {resource.namespace}/{resource.name}"
                 )

--- a/kube_janitor/resource_context.py
+++ b/kube_janitor/resource_context.py
@@ -4,10 +4,47 @@ from typing import Any
 from typing import Dict
 
 from pykube.objects import APIObject
+from pykube.objects import NamespacedAPIObject
 from pykube.objects import Pod
 from pykube.objects import StatefulSet
 
 logger = logging.getLogger(__name__)
+
+
+def get_persistent_volume_claim_context(pvc: NamespacedAPIObject):
+    """Get context for PersistentVolumeClaim: whether it's mounted by a Pod and whether it's referenced by a StatefulSet."""
+    pvc_is_mounted = False
+    pvc_is_referenced = False
+
+    # find out whether a Pod mounts the PVC
+    for pod in Pod.objects(pvc.api, namespace=pvc.namespace):
+        for volume in pod.obj.get("spec", {}).get("volumes", []):
+            if "persistentVolumeClaim" in volume:
+                if volume["persistentVolumeClaim"].get("claimName") == pvc.name:
+                    logger.debug(
+                        f"{pvc.kind} {pvc.namespace}/{pvc.name} is mounted by {pod.kind} {pod.name}"
+                    )
+                    pvc_is_mounted = True
+                    break
+
+    # find out whether the PVC is still referenced somewhere
+    for sts in StatefulSet.objects(pvc.api, namespace=pvc.namespace):
+        # see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+        for claim_template in sts.obj.get("spec", {}).get("volumeClaimTemplates", []):
+            claim_prefix = claim_template.get("metadata", {}).get("name")
+            claim_name_pattern = re.compile(f"^{claim_prefix}-{sts.name}-[0-9]+$")
+            if claim_name_pattern.match(pvc.name):
+                logger.debug(
+                    f"{pvc.kind} {pvc.namespace}/{pvc.name} is referenced by {sts.kind} {sts.name}"
+                )
+                pvc_is_referenced = True
+                break
+
+    # negate the property to make it less error-prone for JMESpath usage
+    return {
+        "pvc_is_not_mounted": not pvc_is_mounted,
+        "pvc_is_not_referenced": not pvc_is_referenced,
+    }
 
 
 def get_resource_context(resource: APIObject):
@@ -16,40 +53,6 @@ def get_resource_context(resource: APIObject):
     context: Dict[str, Any] = {}
 
     if resource.kind == "PersistentVolumeClaim":
-        pvc_is_mounted = False
-        pvc_is_referenced = False
-
-        # find out whether a Pod mounts the PVC
-        for pod in Pod.objects(resource.api, namespace=resource.namespace):
-            for volume in pod.obj.get("spec", {}).get("volumes", []):
-                if "persistentVolumeClaim" in volume:
-                    if (
-                        volume["persistentVolumeClaim"].get("claimName")
-                        == resource.name
-                    ):
-                        logger.debug(
-                            f"{resource.kind} {resource.namespace}/{resource.name} is mounted by {pod.kind} {pod.name}"
-                        )
-                        pvc_is_mounted = True
-                        break
-
-        # find out whether the PVC is still referenced somewhere
-        for sts in StatefulSet.objects(resource.api, namespace=resource.namespace):
-            # see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
-            for claim_template in sts.obj.get("spec", {}).get(
-                "volumeClaimTemplates", []
-            ):
-                claim_prefix = claim_template.get("metadata", {}).get("name")
-                claim_name_pattern = re.compile(f"^{claim_prefix}-{sts.name}-[0-9]+$")
-                if claim_name_pattern.match(resource.name):
-                    logger.debug(
-                        f"{resource.kind} {resource.namespace}/{resource.name} is referenced by {sts.kind} {sts.name}"
-                    )
-                    pvc_is_referenced = True
-                    break
-
-        # negate the property to make it less error-prone for JMESpath usage
-        context["pvc_is_not_mounted"] = not pvc_is_mounted
-        context["pvc_is_not_referenced"] = not pvc_is_referenced
+        context.update(get_persistent_volume_claim_context(resource))
 
     return context

--- a/kube_janitor/resource_context.py
+++ b/kube_janitor/resource_context.py
@@ -1,0 +1,55 @@
+import logging
+import re
+from typing import Any
+from typing import Dict
+
+from pykube.objects import APIObject
+from pykube.objects import Pod
+from pykube.objects import StatefulSet
+
+logger = logging.getLogger(__name__)
+
+
+def get_resource_context(resource: APIObject):
+    """Get additional context information for a single resource, e.g. whether a PVC is mounted/used or not."""
+
+    context: Dict[str, Any] = {}
+
+    if resource.kind == "PersistentVolumeClaim":
+        pvc_is_mounted = False
+        pvc_is_referenced = False
+
+        # find out whether a Pod mounts the PVC
+        for pod in Pod.objects(resource.api, namespace=resource.namespace):
+            for volume in pod.obj.get("spec", {}).get("volumes", []):
+                if "persistentVolumeClaim" in volume:
+                    if (
+                        volume["persistentVolumeClaim"].get("claimName")
+                        == resource.name
+                    ):
+                        logger.debug(
+                            f"{resource.kind} {resource.namespace}/{resource.name} is mounted by {pod.kind} {pod.name}"
+                        )
+                        pvc_is_mounted = True
+                        break
+
+        # find out whether the PVC is still referenced somewhere
+        for sts in StatefulSet.objects(resource.api, namespace=resource.namespace):
+            # see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+            for claim_template in sts.obj.get("spec", {}).get(
+                "volumeClaimTemplates", []
+            ):
+                claim_prefix = claim_template.get("metadata", {}).get("name")
+                claim_name_pattern = re.compile(f"^{claim_prefix}-{sts.name}-[0-9]+$")
+                if claim_name_pattern.match(resource.name):
+                    logger.debug(
+                        f"{resource.kind} {resource.namespace}/{resource.name} is referenced by {sts.kind} {sts.name}"
+                    )
+                    pvc_is_referenced = True
+                    break
+
+        # negate the property to make it less error-prone for JMESpath usage
+        context["pvc_is_not_mounted"] = not pvc_is_mounted
+        context["pvc_is_not_referenced"] = not pvc_is_referenced
+
+    return context

--- a/kube_janitor/rules.py
+++ b/kube_janitor/rules.py
@@ -31,11 +31,13 @@ class Rule(collections.namedtuple("Rule", ["id", "resources", "jmespath", "ttl"]
             ttl=entry["ttl"],
         )
 
-    def matches(self, resource: NamespacedAPIObject):
+    def matches(self, resource: NamespacedAPIObject, context: dict = None):
         if resource.endpoint not in self.resources and "*" not in self.resources:
             return False
 
-        result = self.jmespath.search(resource.obj)
+        data = {"_context": context}
+        data.update(resource.obj)
+        result = self.jmespath.search(data)
         logger.debug(
             f'Rule {self.id} with JMESPath "{self.jmespath.expression}" evaluated for {resource.kind} {resource.namespace}/{resource.name}: {result}'
         )

--- a/tests/test_resource_context.py
+++ b/tests/test_resource_context.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+
+from pykube.objects import PersistentVolumeClaim
+
+from kube_janitor.resource_context import get_resource_context
+
+
+def test_pvc_not_mounted():
+    api_mock = MagicMock(name="APIMock")
+
+    def get(**kwargs):
+        if kwargs.get("url") == "pods":
+            data = {"items": [{"metadata": {"name": "my-pod"}}]}
+        else:
+            data = {}
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api_mock.get = get
+
+    pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "my-pvc"}})
+
+    context = get_resource_context(pvc)
+    assert context["pvc_is_not_mounted"]
+
+
+def test_pvc_mounted():
+    api_mock = MagicMock(name="APIMock")
+
+    def get(**kwargs):
+        if kwargs.get("url") == "pods":
+            data = {
+                "items": [
+                    {
+                        "metadata": {"name": "my-pod"},
+                        "spec": {
+                            "volumes": [
+                                {"persistentVolumeClaim": {"claimName": "my-pvc"}}
+                            ]
+                        },
+                    }
+                ]
+            }
+        else:
+            data = {}
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api_mock.get = get
+
+    pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "my-pvc"}})
+
+    context = get_resource_context(pvc)
+    assert not context["pvc_is_not_mounted"]
+
+
+def test_pvc_is_referenced():
+    api_mock = MagicMock(name="APIMock")
+
+    def get(**kwargs):
+        if kwargs.get("url") == "statefulsets":
+            data = {
+                "items": [
+                    {
+                        "metadata": {"name": "my-sts"},
+                        "spec": {
+                            "volumeClaimTemplates": [{"metadata": {"name": "data"}}]
+                        },
+                    }
+                ]
+            }
+        else:
+            data = {}
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api_mock.get = get
+
+    pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "data-my-sts-0"}})
+
+    context = get_resource_context(pvc)
+    assert not context["pvc_is_not_referenced"]


### PR DESCRIPTION
Add additional context (`_context`) to rules' jmespath evaluation to allow checking whether a PersistentVolumeClaim (PVC) is mounted by a Pod and/or whether the PVC is referenced by a StatefulSet template (`volumeClaimTemplates`).

Fixes #62.