### PR TITLE
Support custom hooks for resource context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,8 @@ Available command line options:
     Optional: filename pointing to a YAML file with a list of rules to apply TTL values to arbitrary Kubernetes objects, e.g. to delete all deployments without a certain label automatically after N days. See Rules File configuration section below.
 ``--deployment-time-annotation``
     Optional: name of the annotation that would be used instead of the creation timestamp of the resource. This option should be used if you want the resources to not be cleaned up if they've been recently redeployed, and your deployment tooling can set this annotation.
+``--resource-context-hook``
+    Optional: string pointing to a Python function to populate the ``_context`` object with additional information, e.g. by calling external services. Built-in example to set ``_context.random_dice`` to a random dice value (1-6): ``--resource-context-hook=kube_janitor.example_hooks.random_dice``.
 
 Example flags:
 

--- a/kube_janitor/example_hooks.py
+++ b/kube_janitor/example_hooks.py
@@ -1,0 +1,30 @@
+"""
+Example resource context hooks for Kubernetes Janitor.
+
+Usage: --resource-context-hook=kube_janitor.example_hooks.random_dice
+"""
+import logging
+import random
+from typing import Any
+from typing import Dict
+
+from pykube.objects import APIObject
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY = "random_dice"
+
+
+def random_dice(resource: APIObject, cache: Dict[str, Any]) -> Dict[str, Any]:
+    """Built-in example resource context hook to set ``_context.random_dice`` to a random dice value (1-6)."""
+
+    # re-use any value from the cache to have only one dice roll per janitor run
+    dice_value = cache.get(CACHE_KEY)
+
+    if dice_value is None:
+        # roll the dice
+        dice_value = random.randint(1, 6)
+        logger.debug(f"The random dice value is {dice_value}!")
+        cache[CACHE_KEY] = dice_value
+
+    return {"random_dice": dice_value}

--- a/kube_janitor/main.py
+++ b/kube_janitor/main.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import logging
 import time
+from typing import Callable
+from typing import Optional
 
 from kube_janitor import __version__
 from kube_janitor import cmd
@@ -43,6 +45,7 @@ def main(args=None):
         args.interval,
         args.delete_notification,
         args.deployment_time_annotation,
+        args.resource_context_hook,
         args.dry_run,
     )
 
@@ -56,8 +59,9 @@ def run_loop(
     rules,
     interval,
     delete_notification,
-    deployment_time_annotation,
-    dry_run,
+    deployment_time_annotation: Optional[str],
+    resource_context_hook: Optional[Callable],
+    dry_run: bool,
 ):
     handler = shutdown.GracefulShutdown()
     while True:
@@ -72,6 +76,7 @@ def run_loop(
                 rules=rules,
                 delete_notification=delete_notification,
                 deployment_time_annotation=deployment_time_annotation,
+                resource_context_hook=resource_context_hook,
                 dry_run=dry_run,
             )
         except Exception as e:

--- a/kube_janitor/resource_context.py
+++ b/kube_janitor/resource_context.py
@@ -60,12 +60,15 @@ def get_resource_context(
 
     context: Dict[str, Any] = {}
 
+    if cache is None:
+        cache = {}
+
     if resource.kind == "PersistentVolumeClaim":
-        context.update(get_persistent_volume_claim_context(resource, cache or {}))
+        context.update(get_persistent_volume_claim_context(resource, cache))
 
     if hook:
         try:
-            context.update(hook(resource, cache or {}))
+            context.update(hook(resource, cache))
         except Exception as e:
             logger.exception(
                 f"Failed populating _context from resource context hook: {e}"

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,6 +1,13 @@
+import kube_janitor.example_hooks
+from kube_janitor.cmd import get_hook_function
 from kube_janitor.cmd import get_parser
 
 
 def test_parse_args():
     parser = get_parser()
     parser.parse_args(["--dry-run", "--rules-file=/config/rules.yaml"])
+
+
+def test_get_example_hook_function():
+    func = get_hook_function("kube_janitor.example_hooks.random_dice")
+    assert func == kube_janitor.example_hooks.random_dice

--- a/tests/test_resource_context.py
+++ b/tests/test_resource_context.py
@@ -1,7 +1,9 @@
 from unittest.mock import MagicMock
 
+from pykube.objects import Namespace
 from pykube.objects import PersistentVolumeClaim
 
+import kube_janitor.example_hooks
 from kube_janitor.resource_context import get_resource_context
 
 
@@ -83,3 +85,16 @@ def test_pvc_is_referenced():
 
     context = get_resource_context(pvc, None, {})
     assert not context["pvc_is_not_referenced"]
+
+
+def test_example_hook():
+    namespace = Namespace(None, {"metadata": {"name": "my-ns"}})
+    hook = kube_janitor.example_hooks.random_dice
+    cache = {}
+    context = get_resource_context(namespace, hook, cache)
+    value = context["random_dice"]
+    assert 1 <= value <= 6
+
+    # check that cache is used
+    new_context = get_resource_context(namespace, hook, cache)
+    assert new_context["random_dice"] == value

--- a/tests/test_resource_context.py
+++ b/tests/test_resource_context.py
@@ -23,7 +23,7 @@ def test_pvc_not_mounted():
 
     pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "my-pvc"}})
 
-    context = get_resource_context(pvc, None, {})
+    context = get_resource_context(pvc)
     assert context["pvc_is_not_mounted"]
 
 
@@ -54,7 +54,7 @@ def test_pvc_mounted():
 
     pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "my-pvc"}})
 
-    context = get_resource_context(pvc, None, {})
+    context = get_resource_context(pvc)
     assert not context["pvc_is_not_mounted"]
 
 
@@ -83,7 +83,7 @@ def test_pvc_is_referenced():
 
     pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "data-my-sts-0"}})
 
-    context = get_resource_context(pvc, None, {})
+    context = get_resource_context(pvc)
     assert not context["pvc_is_not_referenced"]
 
 

--- a/tests/test_resource_context.py
+++ b/tests/test_resource_context.py
@@ -21,7 +21,7 @@ def test_pvc_not_mounted():
 
     pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "my-pvc"}})
 
-    context = get_resource_context(pvc)
+    context = get_resource_context(pvc, None, {})
     assert context["pvc_is_not_mounted"]
 
 
@@ -52,7 +52,7 @@ def test_pvc_mounted():
 
     pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "my-pvc"}})
 
-    context = get_resource_context(pvc)
+    context = get_resource_context(pvc, None, {})
     assert not context["pvc_is_not_mounted"]
 
 
@@ -81,5 +81,5 @@ def test_pvc_is_referenced():
 
     pvc = PersistentVolumeClaim(api_mock, {"metadata": {"name": "data-my-sts-0"}})
 
-    context = get_resource_context(pvc)
+    context = get_resource_context(pvc, None, {})
     assert not context["pvc_is_not_referenced"]


### PR DESCRIPTION
A custom "hook" Python function allows to add arbitrary information to the ``_context`` object in rules, e.g. to gather information from external services such as retrieving GitHub PR status (#45).