### PR TITLE
Unused PVCs: check references by CronJobs/Jobs

### DIFF
--- a/kube_janitor/resource_context.py
+++ b/kube_janitor/resource_context.py
@@ -8,17 +8,18 @@ from typing import Optional
 import jmespath
 from pykube import HTTPClient
 from pykube.objects import APIObject
+from pykube.objects import CronJob
+from pykube.objects import Job
 from pykube.objects import NamespacedAPIObject
 from pykube.objects import Pod
 from pykube.objects import StatefulSet
-
-# from pykube.objects import CronJob
 
 logger = logging.getLogger(__name__)
 
 PVC_REFERENCES = {
     Pod: jmespath.compile("spec.volumes"),
-    # CronJob: "spec.jobTemplate.spec.spec.volumes"
+    Job: jmespath.compile("spec.template.spec.volumes"),
+    CronJob: jmespath.compile("spec.jobTemplate.spec.template.spec.volumes"),
 }
 
 

--- a/kube_janitor/resource_context.py
+++ b/kube_janitor/resource_context.py
@@ -5,13 +5,21 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 
+import jmespath
 from pykube import HTTPClient
 from pykube.objects import APIObject
 from pykube.objects import NamespacedAPIObject
 from pykube.objects import Pod
 from pykube.objects import StatefulSet
 
+# from pykube.objects import CronJob
+
 logger = logging.getLogger(__name__)
+
+PVC_REFERENCES = {
+    Pod: jmespath.compile("spec.volumes"),
+    # CronJob: "spec.jobTemplate.spec.spec.volumes"
+}
 
 
 def get_objects_in_namespace(
@@ -34,29 +42,40 @@ def get_persistent_volume_claim_context(
     pvc_is_mounted = False
     pvc_is_referenced = False
 
-    # find out whether a Pod mounts the PVC
-    for pod in get_objects_in_namespace(Pod, pvc.api, pvc.namespace, cache):
-        for volume in pod.obj.get("spec", {}).get("volumes", []):
-            if "persistentVolumeClaim" in volume:
-                if volume["persistentVolumeClaim"].get("claimName") == pvc.name:
-                    logger.debug(
-                        f"{pvc.kind} {pvc.namespace}/{pvc.name} is mounted by {pod.kind} {pod.name}"
-                    )
-                    pvc_is_mounted = True
-                    break
+    for clazz, volumes_path in PVC_REFERENCES.items():
+        if pvc_is_referenced:
+            break
+        # find out whether the PVC is still mounted by a Pod or referenced by some object
+        for obj in get_objects_in_namespace(clazz, pvc.api, pvc.namespace, cache):
+            for volume in volumes_path.search(obj.obj) or []:
+                if "persistentVolumeClaim" in volume:
+                    if volume["persistentVolumeClaim"].get("claimName") == pvc.name:
+                        if clazz is Pod:
+                            verb = "mounted"
+                            pvc_is_mounted = True
+                        else:
+                            verb = "referenced"
+                        logger.debug(
+                            f"{pvc.kind} {pvc.namespace}/{pvc.name} is {verb} by {obj.kind} {obj.name}"
+                        )
+                        pvc_is_referenced = True
+                        break
 
-    # find out whether the PVC is still referenced somewhere
-    for sts in get_objects_in_namespace(StatefulSet, pvc.api, pvc.namespace, cache):
-        # see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
-        for claim_template in sts.obj.get("spec", {}).get("volumeClaimTemplates", []):
-            claim_prefix = claim_template.get("metadata", {}).get("name")
-            claim_name_pattern = re.compile(f"^{claim_prefix}-{sts.name}-[0-9]+$")
-            if claim_name_pattern.match(pvc.name):
-                logger.debug(
-                    f"{pvc.kind} {pvc.namespace}/{pvc.name} is referenced by {sts.kind} {sts.name}"
-                )
-                pvc_is_referenced = True
-                break
+    if not pvc_is_referenced:
+        # find out whether the PVC is still referenced by a StatefulSet
+        for sts in get_objects_in_namespace(StatefulSet, pvc.api, pvc.namespace, cache):
+            # see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+            for claim_template in sts.obj.get("spec", {}).get(
+                "volumeClaimTemplates", []
+            ):
+                claim_prefix = claim_template.get("metadata", {}).get("name")
+                claim_name_pattern = re.compile(f"^{claim_prefix}-{sts.name}-[0-9]+$")
+                if claim_name_pattern.match(pvc.name):
+                    logger.debug(
+                        f"{pvc.kind} {pvc.namespace}/{pvc.name} is referenced by {sts.kind} {sts.name}"
+                    )
+                    pvc_is_referenced = True
+                    break
 
     # negate the property to make it less error-prone for JMESpath usage
     return {


### PR DESCRIPTION
Make `_context.pvc_is_not_referenced` return `false` if a `CronJob` or `Job` can be found which has a `volumes` property referencing the Persistent Volume Claim (PVC) by name.

Fixes #65.