### PR TITLE
Consider Deployments using PVCs

### DIFF
--- a/kube_janitor/resource_context.py
+++ b/kube_janitor/resource_context.py
@@ -9,6 +9,7 @@ import jmespath
 from pykube import HTTPClient
 from pykube.objects import APIObject
 from pykube.objects import CronJob
+from pykube.objects import Deployment
 from pykube.objects import Job
 from pykube.objects import NamespacedAPIObject
 from pykube.objects import Pod
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 PVC_REFERENCES = {
     Pod: jmespath.compile("spec.volumes[].persistentVolumeClaim"),
     Job: jmespath.compile("spec.template.spec.volumes[].persistentVolumeClaim"),
+    Deployment: jmespath.compile("spec.template.spec.volumes[].persistentVolumeClaim"),
     CronJob: jmespath.compile(
         "spec.jobTemplate.spec.template.spec.volumes[].persistentVolumeClaim"
     ),


### PR DESCRIPTION
Also consider PVC references by Deployments for `_context.pvc_is_not_referenced`.

This will protect PVCs from deletion if they are referenced by a `Deployment` and the following rule exists:

```yaml
- id: remove-unused-pvcs
  resources:
  - persistentvolumeclaims
  jmespath: "_context.pvc_is_not_mounted && _context.pvc_is_not_referenced"
  ttl: 24h
```

Fixes #70.