### PR TITLE
Do not access resources of all namespaces, if `include-namespaces` limits the scope

### DIFF
--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -325,7 +325,8 @@ def clean_up(
             else:
                 logger.debug(f"Skipping {namespace.kind} {namespace}")
     else:
-        for namespace in include_namespaces:
+        for namespace_name in include_namespaces:
+            namespace = Namespace.objects(api).get(name=namespace_name)
             if matches_resource_filter(
                 namespace,
                 include_resources,
@@ -362,25 +363,47 @@ def clean_up(
     for _type in resource_types:
         if _type.endpoint not in exclude_resources:
             try:
-                for resource in _type.objects(api, namespace=pykube.all):
-                    # objects might be available via multiple API versions (e.g. deployments appear as extensions/v1beta1 and apps/v1)
-                    # => process them only once
-                    object_id = (resource.kind, resource.namespace, resource.name)
-                    if object_id in already_seen:
-                        continue
-                    already_seen.add(object_id)
-                    if matches_resource_filter(
-                        resource,
-                        include_resources,
-                        exclude_resources,
-                        include_namespaces,
-                        exclude_namespaces,
-                    ):
-                        filtered_resources.append(resource)
+                if ("all" in include_namespaces):
+                    for resource in _type.objects(api, namespace=pykube.all):
+                        # objects might be available via multiple API versions (e.g. deployments appear as extensions/v1beta1 and apps/v1)
+                        # => process them only once
+                        object_id = (resource.kind, resource.namespace, resource.name)
+                        if object_id in already_seen:
+                            continue
+                        already_seen.add(object_id)
+                        if matches_resource_filter(
+                            resource,
+                            include_resources,
+                            exclude_resources,
+                            include_namespaces,
+                            exclude_namespaces,
+                        ):
+                            filtered_resources.append(resource)
+                        else:
+                            logger.debug(
+                                f"Skipping {resource.kind} {resource.namespace}/{resource.name}"
+                            )
                     else:
-                        logger.debug(
-                            f"Skipping {resource.kind} {resource.namespace}/{resource.name}"
-                        )
+                        for namespace_name in include_namespaces:
+                            for resource in _type.objects(api, namespace=namespace_name):
+                                # objects might be available via multiple API versions (e.g. deployments appear as extensions/v1beta1 and apps/v1)
+                                # => process them only once
+                                object_id = (resource.kind, resource.namespace, resource.name)
+                                if object_id in already_seen:
+                                    continue
+                                already_seen.add(object_id)
+                                if matches_resource_filter(
+                                    resource,
+                                    include_resources,
+                                    exclude_resources,
+                                    include_namespaces,
+                                    exclude_namespaces,
+                                ):
+                                    filtered_resources.append(resource)
+                                else:
+                                    logger.debug(
+                                        f"Skipping {resource.kind} {resource.namespace}/{resource.name}"
+                                    )
             except Exception as e:
                 logger.error(f"Could not list {_type.kind} objects: {e}")
 

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -296,7 +296,7 @@ def clean_up(
     counter: Counter = Counter()
     cache: Dict[str, Any] = {}
 
-    if ("all" in include_namespaces):
+    if "all" in include_namespaces:
         for namespace in Namespace.objects(api):
             if matches_resource_filter(
                 namespace,
@@ -319,7 +319,11 @@ def clean_up(
                 )
                 counter.update(
                     handle_resource_on_expiry(
-                        namespace, rules, delete_notification, wait_after_delete, dry_run
+                        namespace,
+                        rules,
+                        delete_notification,
+                        wait_after_delete,
+                        dry_run,
                     )
                 )
             else:
@@ -348,12 +352,15 @@ def clean_up(
                 )
                 counter.update(
                     handle_resource_on_expiry(
-                        namespace, rules, delete_notification, wait_after_delete, dry_run
+                        namespace,
+                        rules,
+                        delete_notification,
+                        wait_after_delete,
+                        dry_run,
                     )
                 )
             else:
                 logger.debug(f"Skipping {namespace.kind} {namespace}")
-
 
     already_seen: set = set()
 
@@ -363,7 +370,7 @@ def clean_up(
     for _type in resource_types:
         if _type.endpoint not in exclude_resources:
             try:
-                if ("all" in include_namespaces):
+                if "all" in include_namespaces:
                     for resource in _type.objects(api, namespace=pykube.all):
                         # objects might be available via multiple API versions (e.g. deployments appear as extensions/v1beta1 and apps/v1)
                         # => process them only once
@@ -385,10 +392,16 @@ def clean_up(
                             )
                     else:
                         for namespace_name in include_namespaces:
-                            for resource in _type.objects(api, namespace=namespace_name):
+                            for resource in _type.objects(
+                                api, namespace=namespace_name
+                            ):
                                 # objects might be available via multiple API versions (e.g. deployments appear as extensions/v1beta1 and apps/v1)
                                 # => process them only once
-                                object_id = (resource.kind, resource.namespace, resource.name)
+                                object_id = (
+                                    resource.kind,
+                                    resource.namespace,
+                                    resource.name,
+                                )
                                 if object_id in already_seen:
                                     continue
                                 already_seen.add(object_id)

--- a/kube_janitor/janitor.py
+++ b/kube_janitor/janitor.py
@@ -296,33 +296,63 @@ def clean_up(
     counter: Counter = Counter()
     cache: Dict[str, Any] = {}
 
-    for namespace in Namespace.objects(api):
-        if matches_resource_filter(
-            namespace,
-            include_resources,
-            exclude_resources,
-            include_namespaces,
-            exclude_namespaces,
-        ):
-            counter.update(
-                handle_resource_on_ttl(
-                    namespace,
-                    rules,
-                    delete_notification,
-                    deployment_time_annotation,
-                    resource_context_hook,
-                    cache,
-                    wait_after_delete,
-                    dry_run,
+    if ("all" in include_namespaces):
+        for namespace in Namespace.objects(api):
+            if matches_resource_filter(
+                namespace,
+                include_resources,
+                exclude_resources,
+                include_namespaces,
+                exclude_namespaces,
+            ):
+                counter.update(
+                    handle_resource_on_ttl(
+                        namespace,
+                        rules,
+                        delete_notification,
+                        deployment_time_annotation,
+                        resource_context_hook,
+                        cache,
+                        wait_after_delete,
+                        dry_run,
+                    )
                 )
-            )
-            counter.update(
-                handle_resource_on_expiry(
-                    namespace, rules, delete_notification, wait_after_delete, dry_run
+                counter.update(
+                    handle_resource_on_expiry(
+                        namespace, rules, delete_notification, wait_after_delete, dry_run
+                    )
                 )
-            )
-        else:
-            logger.debug(f"Skipping {namespace.kind} {namespace}")
+            else:
+                logger.debug(f"Skipping {namespace.kind} {namespace}")
+    else:
+        for namespace in include_namespaces:
+            if matches_resource_filter(
+                namespace,
+                include_resources,
+                exclude_resources,
+                include_namespaces,
+                exclude_namespaces,
+            ):
+                counter.update(
+                    handle_resource_on_ttl(
+                        namespace,
+                        rules,
+                        delete_notification,
+                        deployment_time_annotation,
+                        resource_context_hook,
+                        cache,
+                        wait_after_delete,
+                        dry_run,
+                    )
+                )
+                counter.update(
+                    handle_resource_on_expiry(
+                        namespace, rules, delete_notification, wait_after_delete, dry_run
+                    )
+                )
+            else:
+                logger.debug(f"Skipping {namespace.kind} {namespace}")
+
 
     already_seen: set = set()
 


### PR DESCRIPTION
Intends to solve #60 

I have added a check before the iteration of namespaces/resources, checking if `include_namespaces` is set to something different than `all`. If yes, only resources within the included namespaces are accessed. With this it is possible to use kube-janitor with `Role` and `RoleBindings` instead of Cluster scope permissions (assuming `--include-namespaces` is set accordingly)

Would be great, if this feature could be included upstream. If you have any suggestions or requirements for this to get merged (this was done rather quickly with some code-duplication) I would be happy to take a crack at those. 